### PR TITLE
refactor license checking code; what sleep depravation does to you rip

### DIFF
--- a/src/actions/publish_action.c
+++ b/src/actions/publish_action.c
@@ -39,55 +39,17 @@ void publish_action(vector_t *arguments) {
 
     char *license_option = get_string_contents("license", package);
     int license = -1;
-    if (strcmp(license_option, "agpl-3.0") == 0) {
-        license = 0;
+    if (!strcmp(license_option, "agpl-3.0")        || !strcmp(license_option, "apache-2.0")
+        || !strcmp(license_option, "artistic-2.0") || !strcmp(license_option, "bsd-2-clause")
+        || !strcmp(license_option, "bsd-3-clause") || !strcmp(license_option, "cc0-1.0")  
+        || !strcmp(license_option, "epl-1.0")      || !strcmp(license_option, "gpl-2.0")  
+        || !strcmp(license_option, "gpl-3.0")      || !strcmp(license_option, "isc")      
+        || !strcmp(license_option, "lgpl-2.1")     || !strcmp(license_option, "lgpl-3.0") 
+        || !strcmp(license_option, "mit")          || !strcmp(license_option, "mpl-2.0")  
+        || !strcmp(license_option, "no-license")   || !strcmp(license_option, "unlicense")) {
+            license = 0;
     }
-    else if (strcmp(license_option, "apache-2.0") == 0) {
-        license = 1;
-    }
-    else if (strcmp(license_option, "artistic-2.0") == 0) {
-        license = 2;
-    }
-    else if (strcmp(license_option, "bsd-2-clause") == 0) {
-        license = 3;
-    }
-    else if (strcmp(license_option, "bsd-3-clause") == 0) {
-        license = 4;
-    }
-    else if (strcmp(license_option, "cc0-1.0") == 0) {
-        license = 5;
-    }
-    else if (strcmp(license_option, "epl-1.0") == 0) {
-        license = 6;
-    }
-    else if (strcmp(license_option, "gpl-2.0") == 0) {
-        license = 7;
-    }
-    else if (strcmp(license_option, "gpl-3.0") == 0) {
-        license = 8;
-    }
-    else if (strcmp(license_option, "isc") == 0) {
-        license = 9;
-    }
-    else if (strcmp(license_option, "lgpl-2.1") == 0) {
-        license = 10;
-    }
-    else if (strcmp(license_option, "lgpl-3.0") == 0) {
-        license = 11;
-    }
-    else if (strcmp(license_option, "mit") == 0) {
-        license = 12;
-    }
-    else if (strcmp(license_option, "mpl-2.0") == 0) {
-        license = 13;
-    }
-    else if (strcmp(license_option, "no-license") == 0) {
-        license = 14;
-    }
-    else if (strcmp(license_option, "unlicense") == 0) {
-        license = 15;
-    }
-
+    
     char *curl_auth = concat(github_username, ":", auth_token, false);
     char *repo_url = concat("http://www.github.com/", github_username, "/", project_name, false);
 
@@ -109,7 +71,7 @@ void publish_action(vector_t *arguments) {
             json_boolean(json, true);
         }
 
-        if (license > -1) {
+        if (license == 0) {
             json_pair(json, "license_template");
             json_string(json, license_option);
         }


### PR DESCRIPTION
i was assigning a different number to `license` every time because I initially thought I'd need that to confirm what license to use. however I'm just taking the license name directly from `license_option`, so all that's necessary is to check whether or not a *valid* license name has been specified.