### PR TITLE
dependency checking kind of works

### DIFF
--- a/include/actions.h
+++ b/include/actions.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <curl/curl.h>
+#include <dirent.h>
 
 #include "load.h"
 #include "util.h"

--- a/src/actions/fetch_action.c
+++ b/src/actions/fetch_action.c
@@ -7,12 +7,24 @@ int dependencies_iterate(any_t data, any_t item_p) {
 
 	char *url = get_array_value(stuff, 0);
     char *version = get_array_value(stuff, 1);
-    char *folder =item->name;
+    char *folder = item->name;
+    if (chdir("_deps") == -1) {
+        printf("error: are you in the Ark project directory?\n");
+        return -1;
+    }
+
+    DIR *dir = opendir(folder);
+    if (dir) {
+        printf("error: clone already exists. Please delete it before retrying.\n");
+        closedir(dir);
+        return -1;
+    }
+    // TODO check git tag version and handle appropriately
 
     // TODO fix this, for some reason concat
     // crashes and burns if you give it more
     // than 5 arguments, so we concat twice
-	char *clone_temp = concat("git clone -b ", version, " --depth 1 ", url, " _deps/");
+	char *clone_temp = concat("git clone -b ", version, " --depth 1 ", url, " ");
     char *clone_process = concat(clone_temp, folder);
 
 	exec_process(clone_process);

--- a/src/actions/fetch_action.c
+++ b/src/actions/fetch_action.c
@@ -15,7 +15,7 @@ int dependencies_iterate(any_t data, any_t item_p) {
 
     DIR *dir = opendir(folder);
     if (dir) {
-        if(chdir(folder)) {
+        if(chdir(folder) == 0) {
             FILE *fp;
             char output[128];
             fp = popen("git tag", "r");
@@ -25,12 +25,11 @@ int dependencies_iterate(any_t data, any_t item_p) {
                 return -2;
             }
             while (fgets(output, sizeof(output) - 1, fp) != NULL) {
-                printf("%s", output);
-                if (!strcmp(version, output)) {
+                if (strcmp(version, output)) {
                     // since we know that the version is the same
                     // just update the repo with a git pull
-                    printf("found same shit. git pulling\n");
-                    char *proc = "git pull";
+                    printf("git pulling...\n");
+                    char *proc = sdsnew("git pull");
                     exec_process(proc);
                     sdsfree(proc);
                     break;

--- a/src/actions/fetch_action.c
+++ b/src/actions/fetch_action.c
@@ -15,9 +15,35 @@ int dependencies_iterate(any_t data, any_t item_p) {
 
     DIR *dir = opendir(folder);
     if (dir) {
-        printf("error: clone already exists. Please delete it before retrying.\n");
-        closedir(dir);
-        return -1;
+        if(chdir(folder)) {
+            FILE *fp;
+            char output[128];
+            fp = popen("git tag", "r");
+            if (fp == NULL) {
+                // TODO better error handling
+                printf("screwed up with git tag checking.");
+                return -2;
+            }
+            while (fgets(output, sizeof(output) - 1, fp) != NULL) {
+                printf("%s", output);
+                if (!strcmp(version, output)) {
+                    // since we know that the version is the same
+                    // just update the repo with a git pull
+                    printf("found same shit. git pulling\n");
+                    char *proc = "git pull";
+                    exec_process(proc);
+                    sdsfree(proc);
+                    break;
+                }
+                // else: we now know that the versions are different
+                // TODO check if remote is greater than local
+                // and perform operation
+            }
+            pclose(fp);
+            closedir(dir);
+            chdir("../");
+            return MAP_OK;
+        }
     }
 
     // TODO fix this, for some reason concat

--- a/src/actions/fetch_action.c
+++ b/src/actions/fetch_action.c
@@ -19,7 +19,6 @@ int dependencies_iterate(any_t data, any_t item_p) {
         closedir(dir);
         return -1;
     }
-    // TODO check git tag version and handle appropriately
 
     // TODO fix this, for some reason concat
     // crashes and burns if you give it more


### PR DESCRIPTION
for differences in `major.minor.patch` between dependencies, the process still needs to be handled appropriately. it currently only works when `major.minor.patch` is equal for both the remote and the local copy, in which case it runs `git pull` to update.