### PR TITLE
use space instead of specifying _deps since we chdir into it

### DIFF
--- a/src/actions/fetch_action.c
+++ b/src/actions/fetch_action.c
@@ -49,7 +49,7 @@ int dependencies_iterate(any_t data, any_t item_p) {
     // TODO fix this, for some reason concat
     // crashes and burns if you give it more
     // than 5 arguments, so we concat twice
-	char *clone_temp = concat("git clone -b ", version, " --depth 1 ", url, " _deps/");
+	char *clone_temp = concat("git clone -b ", version, " --depth 1 ", url, " ");
     char *clone_process = concat(clone_temp, folder);
 
 	exec_process(clone_process);


### PR DESCRIPTION
@felixangell we're doing a chdir into `_deps/` already, so we don't need to do specify it in the `concat`